### PR TITLE
Add object delete protection property

### DIFF
--- a/source/blender/editors/object/object_add.cc
+++ b/source/blender/editors/object/object_add.cc
@@ -2199,6 +2199,10 @@ static int object_delete_exec(bContext *C, wmOperator *op)
   BKE_main_id_tag_all(bmain, ID_TAG_DOIT, false);
 
   CTX_DATA_BEGIN (C, Object *, ob, selected_objects) {
+    if (!ob->can_user_delete) {
+      BKE_report(op->reports, RPT_WARNING, "Object cannot be deleted");
+      continue;
+    }
     if (ob->id.tag & ID_TAG_INDIRECT) {
       /* Can this case ever happen? */
       BKE_reportf(op->reports,

--- a/source/blender/makesdna/DNA_object_defaults.h
+++ b/source/blender/makesdna/DNA_object_defaults.h
@@ -54,6 +54,7 @@
     .duplicator_visibility_flag = OB_DUPLI_FLAG_VIEWPORT | OB_DUPLI_FLAG_RENDER, \
     .pc_ids = {NULL, NULL}, \
     .lineart = { .crease_threshold = DEG2RAD(140.0f) }, \
+    .can_user_delete = 1, \
   }
 
 /** \} */

--- a/source/blender/makesdna/DNA_object_types.h
+++ b/source/blender/makesdna/DNA_object_types.h
@@ -382,7 +382,8 @@ typedef struct Object {
 
   /** ObjectModifierFlag */
   uint8_t modifier_flag;
-  char _pad8[4];
+  char can_user_delete;
+  char _pad8[3];
 
   struct PreviewImage *preview;
 

--- a/source/blender/makesrna/intern/rna_object.cc
+++ b/source/blender/makesrna/intern/rna_object.cc
@@ -160,14 +160,10 @@ static const EnumPropertyItem parent_type_items[] = {
 #define INSTANCE_ITEMS_SHARED \
   {0, "NONE", 0, "None", ""}, \
       {OB_DUPLIVERTS, "VERTS", 0, "Vertices", "Instantiate child objects on all vertices"}, \
-  { \
-    OB_DUPLIFACES, "FACES", 0, "Faces", "Instantiate child objects on all faces" \
-  }
+      {OB_DUPLIFACES, "FACES", 0, "Faces", "Instantiate child objects on all faces"}
 
 #define INSTANCE_ITEM_COLLECTION \
-  { \
-    OB_DUPLICOLLECTION, "COLLECTION", 0, "Collection", "Enable collection instancing" \
-  }
+  {OB_DUPLICOLLECTION, "COLLECTION", 0, "Collection", "Enable collection instancing"}
 static const EnumPropertyItem instance_items[] = {
     INSTANCE_ITEMS_SHARED,
     INSTANCE_ITEM_COLLECTION,
@@ -212,18 +208,9 @@ const EnumPropertyItem rna_enum_lightprobes_type_items[] = {
 };
 
 /* used for 2 enums */
-#define OBTYPE_CU_CURVE \
-  { \
-    OB_CURVES_LEGACY, "CURVE", ICON_OUTLINER_OB_CURVE, "Curve", "" \
-  }
-#define OBTYPE_CU_SURF \
-  { \
-    OB_SURF, "SURFACE", ICON_OUTLINER_OB_SURFACE, "Surface", "" \
-  }
-#define OBTYPE_CU_FONT \
-  { \
-    OB_FONT, "FONT", ICON_OUTLINER_OB_FONT, "Text", "" \
-  }
+#define OBTYPE_CU_CURVE {OB_CURVES_LEGACY, "CURVE", ICON_OUTLINER_OB_CURVE, "Curve", ""}
+#define OBTYPE_CU_SURF {OB_SURF, "SURFACE", ICON_OUTLINER_OB_SURFACE, "Surface", ""}
+#define OBTYPE_CU_FONT {OB_FONT, "FONT", ICON_OUTLINER_OB_FONT, "Text", ""}
 
 const EnumPropertyItem rna_enum_object_type_items[] = {
     {OB_MESH, "MESH", ICON_OUTLINER_OB_MESH, "Mesh", ""},
@@ -406,7 +393,7 @@ static void rna_Object_matrix_world_set(PointerRNA *ptr, const float *values)
 static void rna_Object_matrix_local_get(PointerRNA *ptr, float values[16])
 {
   Object *ob = reinterpret_cast<Object *>(ptr->owner_id);
-  BKE_object_matrix_local_get(ob, (float(*)[4])values);
+  BKE_object_matrix_local_get(ob, (float (*)[4])values);
 }
 
 static void rna_Object_matrix_local_set(PointerRNA *ptr, const float values[16])
@@ -420,10 +407,10 @@ static void rna_Object_matrix_local_set(PointerRNA *ptr, const float values[16])
   if (ob->parent) {
     float invmat[4][4];
     invert_m4_m4(invmat, ob->parentinv);
-    mul_m4_m4m4(local_mat, invmat, (float(*)[4])values);
+    mul_m4_m4m4(local_mat, invmat, (float (*)[4])values);
   }
   else {
-    copy_m4_m4(local_mat, (float(*)[4])values);
+    copy_m4_m4(local_mat, (float (*)[4])values);
   }
 
   /* Don't use compatible so we get predictable rotation, and do not use parenting either,
@@ -434,13 +421,13 @@ static void rna_Object_matrix_local_set(PointerRNA *ptr, const float values[16])
 static void rna_Object_matrix_basis_get(PointerRNA *ptr, float values[16])
 {
   Object *ob = reinterpret_cast<Object *>(ptr->owner_id);
-  BKE_object_to_mat4(ob, (float(*)[4])values);
+  BKE_object_to_mat4(ob, (float (*)[4])values);
 }
 
 static void rna_Object_matrix_basis_set(PointerRNA *ptr, const float values[16])
 {
   Object *ob = reinterpret_cast<Object *>(ptr->owner_id);
-  BKE_object_apply_mat4(ob, (float(*)[4])values, false, false);
+  BKE_object_apply_mat4(ob, (float (*)[4])values, false, false);
 }
 
 void rna_Object_internal_update_data_impl(PointerRNA *ptr)
@@ -3393,6 +3380,13 @@ static void rna_def_object(BlenderRNA *brna)
                            "Add a \"rest_position\" attribute that is a copy of the position "
                            "attribute before shape keys and modifiers are evaluated");
   RNA_def_property_update(prop, NC_OBJECT | ND_DRAW, "rna_Object_internal_update_data");
+
+  prop = RNA_def_property(srna, "can_user_delete", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, nullptr, "can_user_delete", 0);
+  RNA_def_property_boolean_default(prop, true);
+  RNA_def_property_ui_text(
+      prop, "Can User Delete", "Allow user to delete this object through the UI");
+  RNA_def_property_update(prop, NC_OBJECT, nullptr);
 
   /* render */
   prop = RNA_def_property(srna, "pass_index", PROP_INT, PROP_UNSIGNED);


### PR DESCRIPTION
## Summary
- add `can_user_delete` boolean field to `Object`
- expose it in RNA
- initialize to true by default
- prevent deletion of objects with `can_user_delete` disabled

## Testing
- `make format PATHS="source/blender/editors/object/object_add.cc source/blender/editors/space_outliner/outliner_tools.cc source/blender/makesdna/DNA_object_defaults.h source/blender/makesdna/DNA_object_types.h source/blender/makesrna/intern/rna_object.cc"`

------
https://chatgpt.com/codex/tasks/task_e_6849e4e018d0832dad08c370059cb2e5